### PR TITLE
Increase market price variability

### DIFF
--- a/index.html
+++ b/index.html
@@ -1093,35 +1093,35 @@ const marketItems = [
 // Places the player can visit
 const cities = [
   { name: 'York', desc: 'Historic northern city.', fameReq: 0, region: 'north', /* bgColor: 0x2d2d2d, */
-    modifiers: { Potatoes: { buy: 0.9, sell: 1.1 } } },
+    modifiers: { Potatoes: { buy: 0.75, sell: 1.25 } } },
   { name: 'Durham', desc: 'Northern cathedral city.', fameReq: 1, region: 'north', /* bgColor: 0x34342d, */
-    modifiers: { Potatoes: { buy: 0.9, sell: 1.1 } } },
+    modifiers: { Potatoes: { buy: 0.75, sell: 1.25 } } },
   { name: 'Chester', desc: 'Fortified Roman town.', fameReq: 2, region: 'north', /* bgColor: 0x342d34, */
-    modifiers: { Mead: { buy: 0.9, sell: 1.1 } } },
+    modifiers: { Mead: { buy: 0.75, sell: 1.25 } } },
   { name: 'Hull', desc: 'North Sea trading port.', fameReq: 3, region: 'north', /* bgColor: 0x2d342d, */
-    modifiers: { 'Iron Ore': { buy: 0.85, sell: 1.15 } } },
+    modifiers: { 'Iron Ore': { buy: 0.7, sell: 1.3 } } },
   { name: 'Newcastle', desc: 'City on the Tyne.', fameReq: 4, region: 'north', /* bgColor: 0x2d2d34, */
-    modifiers: { Potatoes: { buy: 0.9, sell: 1.1 } } },
+    modifiers: { Potatoes: { buy: 0.75, sell: 1.25 } } },
   { name: 'Lincoln', desc: 'Cathedral and castle city.', fameReq: 5, region: 'north', /* bgColor: 0x342d2d, */
-    modifiers: { Salt: { buy: 0.9, sell: 1.1 } } },
+    modifiers: { Salt: { buy: 0.75, sell: 1.25 } } },
   { name: 'Canterbury', desc: 'Seat of the Archbishop.', fameReq: 6, region: 'south', /* bgColor: 0x2d2d34, */
-    modifiers: { Mead: { buy: 0.9, sell: 1.1 } } },
+    modifiers: { Mead: { buy: 0.75, sell: 1.25 } } },
   { name: 'London', desc: 'Bustling capital of the realm.', fameReq: 7, region: 'south', /* bgColor: 0x34342d, */
-    modifiers: { Salt: { buy: 0.9, sell: 1.1 } } },
+    modifiers: { Salt: { buy: 0.75, sell: 1.25 } } },
   { name: 'Dover', desc: 'Channel crossing hub.', fameReq: 8, region: 'south', /* bgColor: 0x2d342d, */
-    modifiers: { Salt: { buy: 0.9, sell: 1.1 } } },
+    modifiers: { Salt: { buy: 0.75, sell: 1.25 } } },
   { name: 'Norwich', desc: 'Town of fine artisans.', fameReq: 9, region: 'south', /* bgColor: 0x342d2d, */
-    modifiers: { Gemstones: { buy: 0.8, sell: 1.2 } } },
+    modifiers: { Gemstones: { buy: 0.6, sell: 1.4 } } },
   { name: 'Winchester', desc: 'Former royal seat.', fameReq: 10, region: 'south', /* bgColor: 0x2d3434, */
-    modifiers: { Mead: { buy: 0.9, sell: 1.1 } } },
+    modifiers: { Mead: { buy: 0.75, sell: 1.25 } } },
   { name: 'Colchester', desc: 'Ancient Roman city.', fameReq: 11, region: 'south', /* bgColor: 0x34342d, */
-    modifiers: { Mead: { buy: 0.9, sell: 1.1 } } },
+    modifiers: { Mead: { buy: 0.75, sell: 1.25 } } },
   { name: 'Oxford', desc: 'Home of great learning.', fameReq: 12, region: 'south', /* bgColor: 0x2d3434, */
-    modifiers: { 'Silver Cups': { buy: 0.85, sell: 1.15 } } },
+    modifiers: { 'Silver Cups': { buy: 0.7, sell: 1.3 } } },
   { name: 'Southampton', desc: 'Southern port city.', fameReq: 13, region: 'south', /* bgColor: 0x2d2d34, */
-    modifiers: { Gemstones: { buy: 0.8, sell: 1.2 } } },
+    modifiers: { Gemstones: { buy: 0.6, sell: 1.4 } } },
   { name: 'Gloucester', desc: 'Historic Roman city.', fameReq: 14, region: 'south', /* bgColor: 0x34342d, */
-    modifiers: { Potatoes: { buy: 0.9, sell: 1.1 } } }
+    modifiers: { Potatoes: { buy: 0.75, sell: 1.25 } } }
 ];
 
 // Track which cities have been unlocked; start with the current city
@@ -1209,15 +1209,15 @@ function refreshMarketPrices() {
       m.stock = 0;
       return;
     }
-    let buyMult = Phaser.Math.FloatBetween(0.9, 1.1);
-    let sellMult = Phaser.Math.FloatBetween(0.9, 1.1);
+    let buyMult = Phaser.Math.FloatBetween(0.75, 1.25);
+    let sellMult = Phaser.Math.FloatBetween(0.75, 1.25);
     if (city && city.modifiers && city.modifiers[m.name]) {
       const mod = city.modifiers[m.name];
       if (mod.buy) buyMult *= mod.buy;
       if (mod.sell) sellMult *= mod.sell;
     }
-    if (m.name === dailyBuySpecial) buyMult *= 0.75;
-    if (m.name === dailySellSpecial) sellMult *= 1.25;
+    if (m.name === dailyBuySpecial) buyMult *= 0.5;
+    if (m.name === dailySellSpecial) sellMult *= 1.5;
     m.currentBuy = Math.max(1, Math.round(m.buy * buyMult));
     m.currentSell = Math.max(1, Math.round(m.sell * sellMult));
     const cityLevel = city ? city.fameReq || 0 : 0;


### PR DESCRIPTION
## Summary
- Boost daily market fluctuations for more volatile pricing
- Double city trading modifiers and daily specials for bigger bargains and profits

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b55bae9448330a2f64c93bed7daf5